### PR TITLE
Use a dedicated database instead of the default postgres database

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,7 +23,6 @@ PORT=5001
 # Database connection
 DB_HOST_NAME=localhost
 DB_PORT=5432
-DB_NAME=plaid_pattern_account_funding
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 

--- a/.env.template
+++ b/.env.template
@@ -23,6 +23,7 @@ PORT=5001
 # Database connection
 DB_HOST_NAME=localhost
 DB_PORT=5432
+DB_NAME=plaid_pattern_account_funding
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 

--- a/Makefile
+++ b/Makefile
@@ -29,16 +29,17 @@ install: $(envfile)
 
 ## Initialize the database (create tables)
 db-create:
-	psql -U postgres -f database/init/create.sql
+	psql -U postgres -c "CREATE DATABASE plaid_pattern_account_funding" || true
+	psql -U postgres -d plaid_pattern_account_funding -f database/init/create.sql
 
 ## Drop and recreate the database
 db-reset:
-	psql -U postgres -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+	psql -U postgres -c "DROP DATABASE IF EXISTS plaid_pattern_account_funding"
 	$(MAKE) db-create
 
 ## Start an interactive psql session
 sql:
-	psql -U postgres
+	psql -U postgres -d plaid_pattern_account_funding
 
 ## Start the server (port 5001)
 server: $(envfile)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "install:all": "npm install --prefix client && npm install --prefix server",
     "client": "npm start --prefix client",
     "server": "npm start --prefix server",
-    "db:create": "psql -U postgres -f database/init/create.sql",
-    "db:reset": "psql -U postgres -c \"DROP SCHEMA public CASCADE; CREATE SCHEMA public;\" && npm run db:create"
+    "db:create": "psql -U postgres -c \"CREATE DATABASE plaid_pattern_account_funding\" || true && psql -U postgres -d plaid_pattern_account_funding -f database/init/create.sql",
+    "db:reset": "psql -U postgres -c \"DROP DATABASE IF EXISTS plaid_pattern_account_funding\" && npm run db:create"
   }
 }

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -12,6 +12,7 @@ types.setTypeParser(1700, val => parseFloat(val));
 const {
   DB_PORT = '5432',
   DB_HOST_NAME = 'localhost',
+  DB_NAME = 'plaid_pattern_account_funding',
   POSTGRES_USER = 'postgres',
   POSTGRES_PASSWORD = 'password',
 } = process.env;
@@ -20,6 +21,7 @@ const {
 const db = new Pool({
   host: DB_HOST_NAME,
   port: DB_PORT,
+  database: DB_NAME,
   user: POSTGRES_USER,
   password: POSTGRES_PASSWORD,
   max: 5,


### PR DESCRIPTION
## Problem

This issue was introduced by moving this app off of Docker. The server's database pool config specified no `database` name, so it silently connected to PostgreSQL's built-in `postgres` database.

- **Any app or tool that also defaults to `postgres`** — including other Plaid sample apps like `pattern` — would have its schema clobbered by `npm run db:create` or `npm run db:reset`.
- `db:reset` was especially dangerous: it dropped and recreated the `public` schema entirely, wiping everything in `postgres` regardless of what else was living there.
- This isn't specific to running multiple Plaid apps. Anyone with local PostgreSQL tooling, test databases, or other projects that default to the `postgres` database would be at risk.

This mirrors the fix applied to the `pattern` app in plaid/pattern#353.

## Fix

- Introduce `DB_NAME` (defaulting to `plaid_pattern_account_funding`) in `server/db/index.js` and `.env.template`
- Update `db:create` to `CREATE DATABASE plaid_pattern_account_funding` (safe no-op if it already exists) then run the init SQL against it
- Update `db:reset` to `DROP DATABASE IF EXISTS plaid_pattern_account_funding` then recreate it cleanly — scoped only to this app's database

## Test plan

- [ ] `npm run db:create` creates a `plaid_pattern_account_funding` database and initializes tables without touching any other database
- [ ] `npm run db:reset` drops and reinitializes only `plaid_pattern_account_funding`
- [ ] Server connects to `plaid_pattern_account_funding` on startup
- [ ] Existing data in `postgres` or other databases is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 88403007-7862-4b94-8b3f-49ffd44303f0