### PR TITLE
Update Dwolla sandbox docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ This sample app uses Dwolla sandbox to demonstrate the transferring of funds wit
 
 1. Go to your [Plaid developer dashboard Integrations page](https://dashboard.plaid.com/team/integrations). Scroll down to Dwolla and click on the "enable" button.
 
-2. Head to the [Dwolla site](https://developers.dwolla.com/guides/sandbox) and create a sandbox account by clicking the `Get API Keys` button and following the sign up instructions.
+2. Head to the [Dwolla site](https://developers.dwolla.com/docs/testing) and create a sandbox account by clicking the `Get API Keys` button and following the sign up instructions.
 
 3. After logging in, create a temporary access token by clicking on the "Create Token" button on Dwolla's dashboard [Applications Page](https://dashboard-sandbox.dwolla.com/applications-legacy). Copy this token and add it to the .env file as `DWOLLA_ACCESS_TOKEN`. This is a temporary access token issued by Dwolla which is good for one hour.
 4. Go to your Dwolla [Master Account Funding Source](https://dashboard-sandbox.dwolla.com/account/funding-sources) on the dashboard and obtain your id from your Superhero Savings Bank. This is the very last number in the smaller white box on the bottom left corner of the page. Enter this id in the .env file as the `DWOLLA_MASTER_ACCOUNT_ID`.


### PR DESCRIPTION
The Dwolla setup step linked to \`https://developers.dwolla.com/guides/sandbox\`, which 404s. Dwolla moved their sandbox/testing docs to \`https://developers.dwolla.com/docs/testing\` (verified 200 after a 308 redirect from \`/docs/balance/testing\`).

## Test plan
- [ ] Click the "Dwolla site" link in the rendered README and confirm it loads the Dwolla testing/sandbox guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 80ee54fa-3880-4c3c-b81d-9bf74c3adb2c