### PR TITLE
Fix dead Dwolla sandbox docs link in .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -43,7 +43,7 @@ VITE_IS_PROCESSOR=false
 # Dwolla steps:
 # First, enable Dwolla on your Plaid developer dashboard at https://dashboard.plaid.com/team/integrations.
 # Scroll down to Dwolla and click on the 'Enable' button.
-# You will need to open a Dwolla sandbox account at https://developers.dwolla.com/guides/sandbox.
+# You will need to open a Dwolla sandbox account at https://developers.dwolla.com/docs/testing.
 # Go to the Dwolla developer dashboard at https://dashboard-sandbox.dwolla.com/applications-legacy and click the "create token"
 # button in order to create a temporary access token (this is good for one hour).
 # Copy this access token and paste it below as DWOLLA_ACCESS_TOKEN.


### PR DESCRIPTION
The `.env.template` comment pointed to `developers.dwolla.com/guides/sandbox`, which now 404s after Dwolla restructured their developer docs. Repoints it to `developers.dwolla.com/docs/testing` — the current page for the same setup, already referenced in this repo's README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)